### PR TITLE
Makefile: TAGS target for emacs code navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ gst/libgstpulsevideo.so
 gst/gstvideosource1.c
 gst/gstvideosource1.h
 pulsevideo
+TAGS
 tests/__pycache__
 tests/socketintegrationtest
 VERSION

--- a/Makefile
+++ b/Makefile
@@ -214,5 +214,8 @@ build/gstvideosource1.c build/gstvideosource1.h : \
 		--interface-prefix=com.stbtester. \
 		--c-namespace Gst ../$<
 
+TAGS:
+	git ls-files | xargs etags
+
 .PHONY: all clean check dist doc install uninstall
 .PHONY: FORCE TAGS


### PR DESCRIPTION
Curiously enough the Makefile already had TAGS as a phony target but didn't have a rule to actually generate it.