### PR TITLE
Fix buffer reuse

### DIFF
--- a/gst/tmpfile/gstfdpay.c
+++ b/gst/tmpfile/gstfdpay.c
@@ -72,13 +72,10 @@ static void gst_fdpay_dispose (GObject * object);
 
 static GstCaps *gst_fdpay_transform_caps (GstBaseTransform * trans,
     GstPadDirection direction, GstCaps * caps, GstCaps * filter);
-static gboolean gst_fdpay_transform_size (GstBaseTransform *trans,
-    GstPadDirection direction, GstCaps *caps, gsize size, GstCaps *othercaps,
-    gsize *othersize);
 static gboolean gst_fdpay_propose_allocation (GstBaseTransform * trans,
     GstQuery * decide_query, GstQuery * query);
-static GstFlowReturn gst_fdpay_transform (GstBaseTransform * trans,
-    GstBuffer * inbuf, GstBuffer * outbuf);
+static GstFlowReturn gst_fdpay_transform_ip (GstBaseTransform * trans,
+    GstBuffer * buf);
 
 /* pad templates */
 
@@ -127,10 +124,8 @@ gst_fdpay_class_init (GstFdpayClass * klass)
       GST_DEBUG_FUNCPTR (gst_fdpay_transform_caps);
   base_transform_class->propose_allocation =
       GST_DEBUG_FUNCPTR (gst_fdpay_propose_allocation);
-  base_transform_class->transform =
-      GST_DEBUG_FUNCPTR (gst_fdpay_transform);
-  base_transform_class->transform_size =
-      GST_DEBUG_FUNCPTR (gst_fdpay_transform_size);
+  base_transform_class->transform_ip =
+      GST_DEBUG_FUNCPTR (gst_fdpay_transform_ip);
 }
 
 static void
@@ -182,21 +177,6 @@ gst_fdpay_transform_caps (GstBaseTransform * trans, GstPadDirection direction,
   }
 }
 
-static gboolean
-gst_fdpay_transform_size (GstBaseTransform *trans, GstPadDirection direction,
-    GstCaps *caps, gsize size, GstCaps *othercaps, gsize *othersize)
-{
-  if (direction == GST_PAD_SRC) {
-    /* transform size going upstream - don't know how to do this */
-    return FALSE;
-  } else {
-    /* transform size going downstream */
-    *othersize = sizeof (FDMessage);
-  }
-
-  return TRUE;
-}
-
 /* propose allocation query parameters for input buffers */
 static gboolean
 gst_fdpay_propose_allocation (GstBaseTransform * trans,
@@ -235,11 +215,12 @@ gst_fdpay_get_dmabuf_memory (GstFdpay * tmpfilepay, GstBuffer * buffer)
 }
 
 static GstFlowReturn
-gst_fdpay_transform (GstBaseTransform * trans, GstBuffer * inbuf,
-    GstBuffer * outbuf)
+gst_fdpay_transform_ip (GstBaseTransform * trans, GstBuffer * buf)
 {
   GstFdpay *fdpay = GST_FDPAY (trans);
+  GstAllocator *downstream_allocator = NULL;
   GstMemory *dmabufmem = NULL;
+  GstMemory *msgmem;
   GstMapInfo info;
   GError *err = NULL;
   GSocketControlMessage *fdmsg = NULL;
@@ -247,7 +228,8 @@ gst_fdpay_transform (GstBaseTransform * trans, GstBuffer * inbuf,
 
   GST_DEBUG_OBJECT (fdpay, "transform_ip");
 
-  dmabufmem = gst_fdpay_get_dmabuf_memory (fdpay, inbuf);
+  dmabufmem = gst_fdpay_get_dmabuf_memory (fdpay, buf);
+  gst_buffer_remove_all_memory (buf);
 
   msg.size = dmabufmem->size;
   msg.offset = dmabufmem->offset;
@@ -260,12 +242,18 @@ gst_fdpay_transform (GstBaseTransform * trans, GstBuffer * inbuf,
   gst_memory_unref(dmabufmem);
   dmabufmem = NULL;
 
-  gst_buffer_add_net_control_message_meta (outbuf, fdmsg);
+  gst_buffer_add_net_control_message_meta (buf, fdmsg);
   g_clear_object (&fdmsg);
 
-  gst_buffer_map (outbuf, &info, GST_MAP_WRITE);
+  gst_base_transform_get_allocator (trans, &downstream_allocator, NULL);
+  msgmem = gst_allocator_alloc (downstream_allocator, sizeof (FDMessage), NULL);
+  gst_memory_map (msgmem, &info, GST_MAP_WRITE);
   memcpy (info.data, &msg, sizeof (msg));
-  gst_buffer_unmap (outbuf, &info);
+  gst_memory_unmap (msgmem, &info);
+  GST_UNREF (downstream_allocator);
+
+  gst_buffer_append_memory (buf, msgmem);
+  msgmem = NULL;
 
   return GST_FLOW_OK;
 append_fd_failed:

--- a/tests/measure-performance.py
+++ b/tests/measure-performance.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+
+from __future__ import division, unicode_literals
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from collections import namedtuple
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.parse_args(argv[1:])
+
+    subprocess.check_call(['make'], stdout=sys.stderr)
+    version = subprocess.check_output(['git', 'describe', '--always']).strip()
+
+    env = dict(os.environ)
+    env['GST_PLUGIN_PATH'] = os.path.abspath('build')
+    env['LD_LIBRARY_PATH'] = os.path.abspath('build')
+
+    pulsevideo = subprocess.Popen(
+        ['./pulsevideo',
+         '--source-pipeline=videotestsrc is-live=true num-buffers=250',
+         '--caps=video/x-raw, format=I420, width=1280, height=720, '
+         'framerate=25/1'], env=env, stdout=sys.stderr)
+    time.sleep(1)
+    client = subprocess.Popen(
+        ['gst-launch-1.0', 'pulsevideosrc', '!', 'queue',
+         '!', 'xvimagesink'], env=env, stdout=sys.stderr)
+
+    time.sleep(15)
+    pv_info = read_stat_info(pulsevideo.pid)
+    client_info = read_stat_info(client.pid)
+    
+    assert pv_info.state == 'Z'
+    assert client_info.state == 'Z'
+
+    ticks_per_second = os.sysconf(b'SC_CLK_TCK')
+
+    print "%s %f %f %f %f" % (
+        version,
+        pv_info.stime / ticks_per_second,
+        pv_info.utime / ticks_per_second,
+        client_info.stime / ticks_per_second,
+        client_info.utime / ticks_per_second)
+
+    return 0
+
+# From man proc:
+STAT_FIELDS = (
+    'pid comm state ppid pgrp session tty_nr tpgid flags minflt cminflt majflt '
+    'cmajflt utime stime cutime cstime priority nice num_threads itrealvalue '
+    'starttime vsize rss rsslim startcode endcode startstack kstkesp kstkeip '
+    'signal blocked sigignore sigcatch wchan nswap cnswap exit_signal '
+    'processor rt_priority policy delayacct_blkio_ticks guest_time cguest_time '
+    'start_data end_data start_brk arg_start arg_end env_start env_end '
+    'exit_code').split()
+
+StatData = namedtuple("StatData", STAT_FIELDS)
+
+
+def read_stat_info(pid):
+    with open('/proc/%i/stat' % pid) as f:
+        statinfo = f.read().split()
+    for n in [0] + range(3, len(STAT_FIELDS)):
+        statinfo[n] = int(statinfo[n])
+    return StatData(*statinfo)
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Fixes issues #1 and #3.

This is actually a reversion of a previous commit which made fdpay work with GStreamer 1.2 (and thus Ubuntu 14.04). So this PR **breaks pulsevideo on GStreamer 1.2**.  This isn't an issue for my use-case as where I use it the clients may be using GStreamer 1.2, but the pulsevideo daemon runs with GStreamer 1.4.

Surprisingly this commit causes a small *improvement* to performance.  I ran the performance test 46 times both before and after and the results:

<table>
<tr><th></th><th>user</th><th>sys</th><th>total</th>
<tr><td>Without this patch</td><td>2.395</td><td>0.17</td><td>2.6</td></tr>
<tr><td>With this patch</td><td>1.91</td><td>0.345</td><td>2.44</td></tr>
</table>

Each of those values is the median result for streaming 10s/250 frames of 720p25 video.

As expected the amount of time in the kernel has increased with this patch, but the amount of time in userspace has decreased!

**TODO:**

* [x] Write a regression test
* [x] Include more detail in the reversion commit message