### PR TITLE
Validate the sizes of raw video buffers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all:
 
 -include config.mk
 
-PKG_DEPS=gstreamer-1.0 gstreamer-base-1.0 gstreamer-allocators-1.0 gio-2.0 gio-unix-2.0
+PKG_DEPS=gstreamer-1.0 gstreamer-base-1.0 gstreamer-video-1.0 gstreamer-allocators-1.0 gio-2.0 gio-unix-2.0
 
 prefix?=/usr/local
 exec_prefix?=$(prefix)


### PR DESCRIPTION
...to avoid confusing downstream elements.

Sometimes I've seen `v4l2src` produce buffers that are smaller than you would expect based on the caps.  I don't think it's technically an error, but it can certainly surprise downstream elements.