### PR TITLE
Makefile: Add `make shell` for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,12 @@ check-gst-valgrind: ./tests/socketintegrationtest common/
 	         --num-callers=20 \
 	         ./tests/socketintegrationtest
 
+shell:
+	GST_PLUGIN_PATH=$(GST_PLUGIN_PATH):$(CURDIR)/build \
+	    LD_LIBRARY_PATH=$(CURDIR)/build:$(LD_LIBRARY_PATH) \
+	    PATH=$(CURDIR):$(PATH) \
+	    /bin/bash
+
 common/ :
 	git clone git://anongit.freedesktop.org/gstreamer/common common
 


### PR DESCRIPTION
This opens a shell with the envrionment set up such that you don't need to
run `make install` for pulsevideo and the pulsevideo plugins to be picked
up.  This is similar to gst-uninstalled in spirit.