### PR TITLE
TmpFileAllocator: Avoid SIGBUS when /dev/shm is full

### DIFF
--- a/gst/tmpfile/gsttmpfileallocator.c
+++ b/gst/tmpfile/gsttmpfileallocator.c
@@ -71,7 +71,7 @@ tmpfile_create (GstTmpFileAllocator * allocator, gsize size)
   }
   unlink (filename);
 
-  result = ftruncate (fd, size);
+  result = fallocate (fd, 0, 0, size);
   if (result == -1) {
     GST_WARNING_OBJECT (allocator, "Failed to resize temporary file: %s",
         strerror (errno));


### PR DESCRIPTION
`ftruncate` will create a file of the requested size but not reserve
space on the underlying device.  Space is allocated as needed when data
is written into the file.  If there is no space available and we are
writing to the file via a `mmap`ed memory region we get SIGBUS and the
pulsevideo process will crash mysteriously.

With this change we use the linux-specific `fallocate` call to allocate
the space at file creation time.  This is the same solution that the
wayland developers used to [solve a similer problem][way].  We still get
a SIGSEGV if we've run out of space, but at least we provide an error
message to explain what went wrong ("Failed to resize temporary file:
...") rather than receiving a SIGBUS from a seemingly unrelated bit of
code.

`pulsevideo` was tripping over this case when used in a docker container.
[docker limits] `/dev/shm` to 64MB, a limit that we would occasionally
exceed causing pulsevideo to crash.  Of course this commit doesn't remove
this limit, it just provides better clues when it goes wrong.

All in all the proper solution is to be using memfds.  That way we don't
need to rely on certain filesystems to be mounted in certain places and
the memory use would be "charged" to the process that isn't reading
buffers fast enough, rather than filling up /dev/shm and causing
pulsevideo to crash.

[docker limits]: https://github.com/docker/docker/issues/2606
[way]: http://lists.freedesktop.org/archives/wayland-devel/2013-October/011501.html