### PR TITLE
Travis: Use Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: c
 
+sudo: required
+dist: trusty
+
 install:
  - sudo add-apt-repository -y ppa:gstreamer-developers/ppa
  - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 install:
  - sudo add-apt-repository -y ppa:gstreamer-developers/ppa
  - sudo apt-get update
- - sudo apt-get install
+ - sudo apt-get install -y
         gir1.2-gstreamer-1.0
         git
         make


### PR DESCRIPTION
Travis testing has never worked on this repo becase Ubuntu 12.04 doesn't have the necesecary dependencies.  Now it should work on Ubuntu 14.04.

We don't currently run `make check` because that fails due to 7ac5d5ee4b7a6f6749ec15feab0db8a78c7ec2ff.  That can be put off for a future release.