### PR TITLE
Travis: Actually run `make check`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,17 @@ install:
         gir1.2-gstreamer-1.0
         git
         make
+        python-pytest
+        python-pytest-xdist
         gstreamer1.0-plugins-bad
         gstreamer1.0-plugins-base
+        gstreamer1.0-tools
         libgstreamer1.0-dev
         libgstreamer-plugins-base1.0-dev
         valac
+        valgrind
 
 script:
  - make prefix=/usr
+ - make check
  - sudo make install prefix=/usr


### PR DESCRIPTION
Previously we would just check that pulsevideo compiled.  Now we also run `make check`.  As a result I've had to add a bunch of dependencies which are just for `make check`.

This doesn't currently pass due to 7ac5d5ee4b7a6f6749ec15feab0db8a78c7ec2ff.  pulsevideosrc is supported on Ubuntu 14.04, but the pulsevideo daemon requires GStreamer 1.4, so Ubuntu 14.10 or later.  This mismatch is possible by running pulsevideo in one container and pulsevideosrc in another.

**TODO**:
- [ ] Fix make check, possibly by:
  - either installing GStreamer 1.4
  - or using a later version of Ubuntu than 14.04
  - or using docker to build and run the pulsevideo daemon.
