### PR TITLE
Create pulsevideosink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@ build/
 common/
 config.mk
 gst/libgstpulsevideo.so
-gst/gstvideosource1.c
-gst/gstvideosource1.h
+gst/gstvideosource2.c
+gst/gstvideosource2.h
 pulsevideo
 TAGS
 tests/__pycache__

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,7 @@ build/%.h : gst/%.h Makefile | build/debugutils build/tcp build/tmpfile build/gs
 	      >$@
 
 build/libgstpulsevideo.so : \
+		build/glib_compat.h \
 		build/gst-plugins-base/gst-libs/gst/allocators/gstfdmemory.h \
 		build/gst-plugins-base/gst-libs/gst/allocators/gstfdmemory.c \
 		build/gstpulsevideosink.h \

--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,8 @@ build/%.h : gst/%.h Makefile | build/debugutils build/tcp build/tmpfile build/gs
 build/libgstpulsevideo.so : \
 		build/gst-plugins-base/gst-libs/gst/allocators/gstfdmemory.h \
 		build/gst-plugins-base/gst-libs/gst/allocators/gstfdmemory.c \
+		build/gstpulsevideosink.h \
+		build/gstpulsevideosink.c \
 		build/gstpulsevideosrc.h \
 		build/gstpulsevideosrc.c \
 		build/gstnetcontrolmessagemeta.c \

--- a/Makefile
+++ b/Makefile
@@ -216,8 +216,8 @@ build/libgstpulsevideo.so : \
 		build/gstsocketsrc.c \
 		build/gstrawvideovalidate.h \
 		build/gstrawvideovalidate.c \
-		build/gstvideosource1.c \
-		build/gstvideosource1.h \
+		build/gstvideosource2.c \
+		build/gstvideosource2.h \
 		build/debugutils/gstwatchdog.h \
 		build/debugutils/gstwatchdog.c \
 		build/tcp/gstmultihandlesink.h \
@@ -242,7 +242,7 @@ build/libgstpulsevideo.so : \
 		$$(pkg-config --libs --cflags $(PKG_DEPS)) \
 		-DVERSION=\"$(VERSION)\" -DPACKAGE="\"pulsevideo\""
 
-build/gstvideosource1.c build/gstvideosource1.h : \
+build/gstvideosource2.c build/gstvideosource2.h : \
 		dbus-xml/com.stbtester.VideoSource2.xml
 	cd $(dir $@) && \
 	gdbus-codegen \

--- a/gst/glib_compat.h
+++ b/gst/glib_compat.h
@@ -1,0 +1,24 @@
+#ifndef __PV_GLIB_COMPAT_H_
+#define __PV_GLIB_COMPAT_H_
+
+#include <glib.h>
+
+#ifndef g_steal_pointer
+static inline gpointer
+(g_steal_pointer) (gpointer pp)
+{
+  gpointer *ptr = pp;
+  gpointer ref;
+
+  ref = *ptr;
+  *ptr = NULL;
+
+  return ref;
+}
+
+/* type safety */
+#define g_steal_pointer(pp) \
+  (0 ? (*(pp)) : (g_steal_pointer) (pp))
+#endif
+
+#endif  /* __PV_GLIB_COMPAT_H_ */

--- a/gst/gstpulsevideoplugin.c
+++ b/gst/gstpulsevideoplugin.c
@@ -22,6 +22,7 @@
 #endif
 
 #include "gstsocketsrc.h"
+#include "gstpulsevideosink.h"
 #include "gstpulsevideosrc.h"
 #include "gstrawvideovalidate.h"
 #include "debugutils/gstwatchdog.h"
@@ -35,6 +36,8 @@ plugin_init (GstPlugin * plugin)
   return
     gst_element_register (plugin, "pvsocketsrc", GST_RANK_NONE,
           GST_TYPE_SOCKET_SRC) &&
+    gst_element_register (plugin, "pulsevideosink", GST_RANK_NONE,
+          GST_TYPE_PULSEVIDEO_SINK) &&
     gst_element_register (plugin, "pulsevideosrc", GST_RANK_NONE,
           GST_TYPE_PULSEVIDEO_SRC) &&
     gst_element_register (plugin, "pvmultisocketsink", GST_RANK_NONE,

--- a/gst/gstpulsevideosink.c
+++ b/gst/gstpulsevideosink.c
@@ -31,6 +31,7 @@
  * </refsect2>
  */
 
+#include "glib_compat.h"
 #include "gstpulsevideosink.h"
 #include <string.h>
 #include <gio/gunixfdlist.h>

--- a/gst/gstpulsevideosink.c
+++ b/gst/gstpulsevideosink.c
@@ -1,0 +1,424 @@
+/* GStreamer
+ * Copyright (C) <2016> William Manley <will@williammanley.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/**
+ * SECTION:element-pulsevideosink
+ *
+ * <refsect2>
+ * <title>Example launch line</title>
+ * |[
+ * # server:
+ * gst-launch-1.0 videotestsrc ! pulsevideosink
+ * # client:
+ * gst-launch-1.0 pulsevideosrc ! xvimagesink
+ * ]|
+ * </refsect2>
+ */
+
+#include "gstpulsevideosink.h"
+#include <string.h>
+#include <gio/gunixfdlist.h>
+#include <gst/base/gstbasesink.h>
+#include <gst/video/video.h>
+
+#include <sys/socket.h>
+
+GST_DEBUG_CATEGORY_STATIC (pulsevideosink_debug);
+#define GST_CAT_DEFAULT pulsevideosink_debug
+
+#define SWAP(x,y) do \
+   { unsigned char swap_temp[sizeof(x) == sizeof(y) ? (signed)sizeof(x) : -1]; \
+     memcpy(swap_temp,&y,sizeof(x)); \
+     memcpy(&y,&x,       sizeof(x)); \
+     memcpy(&x,swap_temp,sizeof(x)); \
+    } while(0)
+
+enum
+{
+  PROP_0,
+  PROP_DBUS_CONNECTION,
+  PROP_BUS_NAME,
+  PROP_OBJECT_PATH,
+  PROP_CAPS,
+};
+
+#define gst_pulsevideo_sink_parent_class parent_class
+G_DEFINE_TYPE (GstPulseVideoSink, gst_pulsevideo_sink, GST_TYPE_BIN);
+
+
+static void gst_pulsevideo_sink_dispose (GObject * gobject);
+static void gst_pulsevideo_sink_finalize (GObject * gobject);
+
+static gboolean gst_pulsevideo_sink_stop (GstPulseVideoSink * bsink);
+static gboolean gst_pulsevideo_sink_start (GstPulseVideoSink * bsink);
+
+static void gst_pulsevideo_sink_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec);
+static void gst_pulsevideo_sink_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec);
+
+static GstStateChangeReturn gst_pulsevideo_sink_change_state (
+    GstElement * element, GstStateChange transition);
+static gboolean on_handle_attach (GstVideoSource2 *interface,
+    GDBusMethodInvocation *invocation, GUnixFDList* fdlist, gpointer user_data);
+
+
+static void
+gst_pulsevideo_sink_class_init (GstPulseVideoSinkClass * klass)
+{
+  GObjectClass *gobject_class;
+  GstElementClass *gstelement_class;
+
+  gobject_class = (GObjectClass *) klass;
+  gstelement_class = (GstElementClass *) klass;
+
+  gobject_class->set_property = gst_pulsevideo_sink_set_property;
+  gobject_class->get_property = gst_pulsevideo_sink_get_property;
+  gobject_class->dispose = gst_pulsevideo_sink_dispose;
+  gobject_class->finalize = gst_pulsevideo_sink_finalize;
+
+  g_object_class_install_property (gobject_class, PROP_DBUS_CONNECTION,
+      g_param_spec_object ("dbus-connection", "DBus Connection",
+          "The connection to the DBus bus that the video should be served on",
+          G_TYPE_DBUS_CONNECTION, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property (gobject_class, PROP_BUS_NAME,
+      g_param_spec_string ("bus-name", "Bus Name",
+          "The DBus bus name of the video source",
+          "com.stbtester.VideoSource.dev_video0",
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT));
+  g_object_class_install_property (gobject_class, PROP_OBJECT_PATH,
+      g_param_spec_string ("object-path", "Object Path",
+          "The DBus object path of the video source",
+          "/com/stbtester/VideoSource",
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT));
+  g_object_class_install_property (gobject_class, PROP_CAPS,
+      g_param_spec_string ("caps", "Caps", "Caps to use",
+          "video/x-raw,format=BGR,width=1280,height=720,framerate=30/1,interlace-mode=progressive",
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT));
+
+  gst_element_class_set_static_metadata (gstelement_class,
+      "PulseVideo sink", "Source/DBus",
+      "Publish data on DBus by exposing the com.stbtester.VideoSource2 "
+      "interface", "William Manley <will@williammanley.net>");
+
+  gstelement_class->change_state = gst_pulsevideo_sink_change_state;
+  GST_DEBUG_CATEGORY_INIT (pulsevideosink_debug, "pulsevideosink", 0,
+      "PulseVideo Source");
+}
+
+static void
+gst_pulsevideo_sink_init (GstPulseVideoSink * this)
+{
+  GstPad *internal_pad, *external_pad;
+  GstElement *rawvideovalidate = NULL;
+
+  this->capsfilter = gst_element_factory_make ("capsfilter", NULL);
+  gst_bin_add (GST_BIN (this), gst_object_ref (this->capsfilter));
+  this->fdpay = gst_element_factory_make ("pvfdpay", NULL);
+  gst_bin_add (GST_BIN (this), gst_object_ref (this->fdpay));
+  this->socketsink = gst_parse_bin_from_description_full (
+      "pvmultisocketsink buffers-max=2"
+      "                  buffers-soft-max=1"
+      "                  recover-policy=latest"
+      "                  sync-method=latest"
+      "                  sync=FALSE"
+      "                  enable-last-sample=FALSE",
+      TRUE, NULL, GST_PARSE_FLAG_NO_SINGLE_ELEMENT_BINS, NULL);
+  gst_bin_add (GST_BIN (this), gst_object_ref (this->socketsink));
+  gst_element_link_many (
+        this->capsfilter, this->fdpay, this->socketsink, rawvideovalidate,
+        NULL);
+
+  internal_pad = gst_element_get_static_pad (this->capsfilter, "sink");
+  external_pad = gst_ghost_pad_new ("sink", internal_pad);
+  gst_element_add_pad (GST_ELEMENT (this), external_pad);
+  gst_object_unref (internal_pad);
+
+
+  this->dbus_interface = gst_video_source2_skeleton_new ();
+
+  g_signal_connect_object (this->dbus_interface,
+                           "handle-attach",
+                           G_CALLBACK (on_handle_attach),
+                           this, 0);
+}
+
+static void
+gst_pulsevideo_sink_dispose (GObject * gobject)
+{
+  GstPulseVideoSink *this = GST_PULSEVIDEO_SINK (gobject);
+
+  g_clear_object (&this->dbus);
+  g_clear_object (&this->dbus_interface);
+  g_clear_object (&this->capsfilter);
+  g_clear_object (&this->fdpay);
+  g_clear_object (&this->socketsink);
+
+  G_OBJECT_CLASS (parent_class)->dispose (gobject);
+}
+
+static void
+gst_pulsevideo_sink_finalize (GObject * gobject)
+{
+  GstPulseVideoSink *this = GST_PULSEVIDEO_SINK (gobject);
+
+  g_free (g_steal_pointer (&this->bus_name));
+  g_free (g_steal_pointer (&this->object_path));
+
+  G_OBJECT_CLASS (parent_class)->finalize (gobject);
+}
+
+static void
+gst_pulsevideo_sink_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  GstPulseVideoSink *sink = GST_PULSEVIDEO_SINK (object);
+
+  switch (prop_id) {
+    case PROP_DBUS_CONNECTION: {
+      GDBusConnection *conn;
+      conn = g_value_get_object (value);
+      GST_OBJECT_LOCK (sink);
+      SWAP (conn, sink->dbus);
+      GST_OBJECT_UNLOCK (sink);
+      g_clear_object (&conn);
+      break;
+    }
+    case PROP_BUS_NAME: {
+      gchar * bus_name = g_value_dup_string (value);
+      GST_OBJECT_LOCK (sink);
+      SWAP (bus_name, sink->bus_name);
+      GST_OBJECT_UNLOCK (sink);
+      g_free (bus_name);
+      break;
+    }
+    case PROP_OBJECT_PATH: {
+      gchar * object_path = g_value_dup_string (value);
+      if (g_variant_is_object_path(object_path)) {
+        GST_OBJECT_LOCK (sink);
+        SWAP (object_path, sink->object_path);
+        GST_OBJECT_UNLOCK (sink);
+      }
+      else
+        GST_WARNING_OBJECT (sink, "Not setting property \"object-path\": \"%s\" "
+            "is not a valid object path", object_path);
+      g_free (object_path);
+      break;
+    }
+    case PROP_CAPS: {
+      GstCaps * caps = gst_caps_from_string (g_value_get_string (value));
+
+      /* Convert back to normalise the caps: */
+      gchar* capsstring = gst_caps_to_string (caps);
+
+      g_object_set (sink->capsfilter, "caps", caps, NULL);
+      g_object_set (G_OBJECT (sink->dbus_interface), "caps", capsstring, NULL);
+      g_free (capsstring);
+      gst_caps_unref (g_steal_pointer (&caps));
+      break;
+    }
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+gst_pulsevideo_sink_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  GstPulseVideoSink *pulsevideosink = GST_PULSEVIDEO_SINK (object);
+
+  switch (prop_id) {
+    case PROP_DBUS_CONNECTION:
+      GST_OBJECT_LOCK (pulsevideosink);
+      g_value_set_object (value, pulsevideosink->dbus);
+      GST_OBJECT_UNLOCK (pulsevideosink);
+      break;
+    case PROP_BUS_NAME:
+      GST_OBJECT_LOCK (pulsevideosink);
+      g_value_set_string (value, pulsevideosink->bus_name);
+      GST_OBJECT_UNLOCK (pulsevideosink);
+      break;
+    case PROP_OBJECT_PATH: {
+      GST_OBJECT_LOCK (pulsevideosink);
+      g_value_set_string (value, pulsevideosink->object_path);
+      GST_OBJECT_UNLOCK (pulsevideosink);
+      break;
+    }
+    case PROP_CAPS: {
+      GST_OBJECT_LOCK (pulsevideosink);
+      g_object_get_property (G_OBJECT (pulsevideosink->dbus_interface), "caps",
+          value);
+      GST_OBJECT_UNLOCK (pulsevideosink);
+      break;
+    }
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static GstStateChangeReturn
+gst_pulsevideo_sink_change_state (GstElement * element,
+    GstStateChange transition)
+{
+  GstPulseVideoSink *sink;
+  GstStateChangeReturn result;
+
+  sink = GST_PULSEVIDEO_SINK (element);
+
+  if (transition == GST_STATE_CHANGE_READY_TO_PAUSED) {
+    if (!gst_pulsevideo_sink_start ((GstPulseVideoSink*) element)) {
+      result = GST_STATE_CHANGE_FAILURE;
+      goto failure;
+    }
+  }
+  if ((result = GST_ELEMENT_CLASS (parent_class)->change_state (element,
+              transition)) == GST_STATE_CHANGE_FAILURE)
+    goto failure;
+
+  if (transition == GST_STATE_CHANGE_PAUSED_TO_READY) {
+    gst_pulsevideo_sink_stop ((GstPulseVideoSink *)element);
+  }
+
+  return result;
+
+  /* ERRORS */
+failure:
+  {
+    GST_DEBUG_OBJECT (sink, "parent failed state change");
+    return result;
+  }
+}
+
+static gboolean
+on_handle_attach (GstVideoSource2         *interface,
+                  GDBusMethodInvocation   *invocation,
+                  GUnixFDList             *fdlist,
+                  gpointer                user_data)
+{
+  GstPulseVideoSink * sink = (GstPulseVideoSink*) user_data;
+  int fds[2] = {-1, -1};
+
+  GSocket* our_socket = NULL;
+  GVariant *their_socket_idx = NULL;
+  GUnixFDList *their_socket_list = NULL;
+  GError * gerror = NULL;
+  int error = 0;
+
+  GST_DEBUG_OBJECT (sink, "Attaching client");
+
+  error = socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, fds);
+  if (error) {
+    g_set_error (&gerror, G_IO_ERROR, g_io_error_from_errno (errno),
+        "socketpair failed with errno %i (%s)", errno, strerror(errno));
+    goto out;
+  }
+
+  our_socket = g_socket_new_from_fd (fds[0], &gerror);
+  if (our_socket == NULL) {
+    goto out;
+  }
+  fds[0] = -1;
+
+  their_socket_idx = g_variant_new_handle(0);
+  their_socket_list = g_unix_fd_list_new_from_array(&fds[1], 1);
+  fds[1] = -1;
+
+  g_signal_emit_by_name (sink->socketsink, "add", our_socket, NULL);
+
+  gst_video_source2_complete_attach (
+      g_steal_pointer(&interface), invocation, their_socket_list,
+      their_socket_idx);
+
+out:
+  if (gerror) {
+    GST_WARNING_OBJECT(sink, "Attach failed: %s", gerror->message);
+    g_dbus_method_invocation_return_gerror(
+        g_steal_pointer(&invocation), gerror);
+    g_clear_error (&gerror);
+  }
+  close (fds[0]);
+  close (fds[1]);
+  g_clear_object (&our_socket);
+//  if (their_socket_idx)
+//    g_variant_unref (their_socket_idx);
+  g_clear_object (&their_socket_list);
+  return TRUE;
+}
+
+GDBusConnection * connect_to_dbus(GDBusConnection * connection, GError ** error)
+{
+  if (connection)
+    return g_object_ref (connection);
+  connection = g_bus_get_sync (G_BUS_TYPE_STARTER, NULL, NULL);
+  if (connection)
+    return connection;
+  connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, error);
+  return connection;
+}
+
+/* create a socket for connecting to remote server */
+static gboolean
+gst_pulsevideo_sink_start (GstPulseVideoSink * sink)
+{
+  GError *error = NULL;
+  gboolean ret = FALSE;
+
+  GST_OBJECT_LOCK (sink);
+  sink->connection_in_use = connect_to_dbus (sink->dbus, &error);
+  if (sink->connection_in_use == NULL) {
+    GST_ERROR_OBJECT (sink, "Failed to connect to DBus");
+    goto out;
+  }
+  if (!g_dbus_interface_skeleton_export (
+          G_DBUS_INTERFACE_SKELETON (sink->dbus_interface),
+          sink->connection_in_use, sink->object_path, &error))
+  {
+    GST_ERROR_OBJECT (sink, "Failed to export dbus object on path %s: %s",
+        sink->object_path, error->message);
+    goto out;
+  }
+
+  sink->bus_name_token = g_bus_own_name_on_connection (sink->connection_in_use,
+      sink->bus_name, 0, NULL, NULL, NULL, NULL);
+
+  ret = TRUE;
+out:
+  GST_OBJECT_UNLOCK (sink);
+  g_clear_error (&error);
+  return ret;
+}
+
+static gboolean
+gst_pulsevideo_sink_stop (GstPulseVideoSink * bsink)
+{
+  GstPulseVideoSink *sink = GST_PULSEVIDEO_SINK (bsink);
+
+  GST_OBJECT_LOCK (sink);
+  g_bus_unown_name (sink->bus_name_token);
+  sink->bus_name_token = 0;
+  g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (
+      sink->dbus_interface));
+  g_clear_object (&sink->connection_in_use);
+  GST_OBJECT_UNLOCK (sink);
+  
+  return TRUE;
+}

--- a/gst/gstpulsevideosink.h
+++ b/gst/gstpulsevideosink.h
@@ -1,0 +1,72 @@
+/* GStreamer
+ * Copyright (C) <2016> William Manley <will@williammanley.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef __GST_PULSEVIDEO_SINK_H__
+#define __GST_PULSEVIDEO_SINK_H__
+
+#include <gst/gst.h>
+#include <gst/gstbin.h>
+
+#include <gio/gio.h>
+#include "gstvideosource2.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_PULSEVIDEO_SINK \
+  (gst_pulsevideo_sink_get_type())
+#define GST_PULSEVIDEO_SINK(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PULSEVIDEO_SINK,GstPulseVideoSink))
+#define GST_PULSEVIDEO_SINK_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_PULSEVIDEO_SINK,GstPulseVideoSinkClass))
+#define GST_IS_PULSEVIDEO_SINK(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PULSEVIDEO_SINK))
+#define GST_IS_PULSEVIDEO_SINK_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_PULSEVIDEO_SINK))
+
+typedef struct _GstPulseVideoSink GstPulseVideoSink;
+typedef struct _GstPulseVideoSinkClass GstPulseVideoSinkClass;
+
+struct _GstPulseVideoSink {
+  GstBin element;
+
+  /*< private >*/
+  GstElement *capsfilter;
+  GstElement *fdpay;
+  GstElement *socketsink;
+
+  GDBusConnection *dbus;
+  gchar *bus_name;
+  gchar *object_path;
+  gboolean wait_for_connection;
+
+  GDBusConnection *connection_in_use;
+  GstVideoSource2 *dbus_interface;
+  gint bus_name_token;
+};
+
+struct _GstPulseVideoSinkClass {
+  GstBinClass parent_class;
+};
+
+GType gst_pulsevideo_sink_get_type (void);
+
+G_END_DECLS
+
+#endif /* __GST_PULSEVIDEO_SINK_H__ */

--- a/gst/gstpulsevideosrc.c
+++ b/gst/gstpulsevideosrc.c
@@ -32,7 +32,7 @@
  */
 
 #include "gstpulsevideosrc.h"
-#include "gstvideosource1.h"
+#include "gstvideosource2.h"
 #include <string.h>
 #include <gio/gunixfdlist.h>
 #include <gst/base/gstbasesrc.h>

--- a/pulsevideo.vala
+++ b/pulsevideo.vala
@@ -2,97 +2,49 @@ using GLib;
 using Gst;
 using Posix;
 
-
-[DBus (name = "com.stbtester.VideoSource2")]
-public interface VideoSource2 : GLib.Object {
-
-    public abstract string caps { owned get; }
-    public abstract GLib.UnixInputStream attach () throws Error;
-}
-
-GLib.Error ioerror_from_errno (int err_no, string msg)
+public void handle_message (Gst.Message message)
 {
-    return new GLib.Error(IOError.quark(), g_io_error_from_errno(err_no),
-        msg);
-}
-
-public class VideoSource : GLib.Object, VideoSource2 {
-
-    public string caps { owned get { return caps_; } }
-    private string caps_;
-    private Gst.Element multisocketsink;
-    private Gst.Pipeline pipeline;
-
-    public VideoSource (string caps, Gst.Pipeline pipeline,
-            Gst.Element multisocketsink)
-    {
-        this.caps_ = caps;
-        this.multisocketsink = multisocketsink;
-        this.pipeline = pipeline;
-
-        var bus = pipeline.get_bus();
-        bus.add_signal_watch();
-        bus.message.connect(handle_message);
-    }
-
-    public GLib.UnixInputStream attach () throws Error
-    {
-        GLib.stderr.printf("Attaching client, entering PLAYING state\n");
-        pipeline.set_state(Gst.State.PLAYING);
-
-        var fds = new int[2];
-        var error = Posix.socketpair (Posix.AF_UNIX, Posix.SOCK_STREAM, 0,
-            fds);
-        if (error != 0) {
-            throw ioerror_from_errno(GLib.errno, "socketpair failed");
-        }
-        var wtr = new GLib.Socket.from_fd(fds[0]);
-        GLib.Signal.emit_by_name(multisocketsink, "add", wtr, null);
-
-        return new GLib.UnixInputStream(fds[1], true);
-    }
-
-    public void handle_message (Gst.Message message)
-    {
-        switch (message.type) {
-        case Gst.MessageType.ERROR:
-            GLib.Error error;
-            string debug;
-            message.parse_error(out error, out debug);
-            GLib.stderr.printf("Error: %s\n%s\n", error.message, debug);
-            exit (1);
-            break;
-        case Gst.MessageType.WARNING:
-            GLib.Error error;
-            string debug;
-            message.parse_warning(out error, out debug);
-            GLib.stderr.printf("Warning: %s\n%s\n", error.message, debug);
-            break;
-        }
+    switch (message.type) {
+    case Gst.MessageType.ERROR:
+        GLib.Error error;
+        string debug;
+        message.parse_error(out error, out debug);
+        GLib.stderr.printf("Error: %s\n%s\n", error.message, debug);
+        exit (1);
+        break;
+    case Gst.MessageType.WARNING:
+        GLib.Error error;
+        string debug;
+        message.parse_warning(out error, out debug);
+        GLib.stderr.printf("Warning: %s\n%s\n", error.message, debug);
+        break;
     }
 }
 
-void create_videosource(string source, string caps, GLib.DBusConnection dbus,
-        string object_path) throws Error
+Gst.Pipeline create_videosource(string source, string caps, string object_path,
+    string bus_name_suffix) throws Error
 {
     // Creating pipeline and elements
     var pipeline = (Gst.Pipeline) Gst.parse_launch(
-        source + " ! pvwatchdog ! " + caps + " ! pvfdpay "
-        + " ! pvmultisocketsink buffers-max=2 buffers-soft-max=1 "
-        + "recover-policy=latest sync-method=latest name=sink sync=false "
-        + "enable-last-sample=false");
+        source + " ! pvwatchdog ! pulsevideosink caps=\"" + caps
+        + "\" object-path=\"" + object_path + "\" " +
+        "bus-name=\"com.stbtester.VideoSource." + bus_name_suffix + "\"");
 
-    var sink = pipeline.get_by_name("sink");
+    var bus = pipeline.get_bus();
+    bus.add_signal_watch();
+    bus.message.connect(handle_message);
 
-    dbus.register_object(object_path,
-        (VideoSource2) new VideoSource(caps, pipeline, sink));
+    pipeline.set_state(Gst.State.PLAYING);
+
+    return pipeline;
 }
 
 int main (string[] args) {
     string? source_pipeline = "v4l2src";
     string? caps =
-        "video/x-raw,format=BGR,width=1280,height=720,framerate=30/1";
+        "video/x-raw,format=BGR,width=1280,height=720,framerate=30/1,interlace-mode=progressive";
     string? name = "dev_video0";
+    Gst.Pipeline pipeline;
     GLib.OptionEntry[] options = {
         GLib.OptionEntry () {
             long_name = "caps", short_name = 0, flags = 0,
@@ -128,21 +80,8 @@ int main (string[] args) {
     Gst.init (ref args);
 
     try {
-        var dbus = GLib.Bus.get_sync (BusType.SESSION);
-
-        create_videosource(
-            source_pipeline, caps, dbus, "/com/stbtester/VideoSource");
-
-        uint32 request_name_result = 0;
-        dbus.call_sync (
-            "org.freedesktop.DBus", "/org/freedesktop/DBus",
-            "org.freedesktop.DBus", "RequestName",
-            new Variant ("(su)", "com.stbtester.VideoSource." + name, 0x4),
-            null, 0, -1).get("(u)", &request_name_result);
-        if (request_name_result == 0) {
-            GLib.stderr.printf ("Could not register name on DBus");
-            return 1;
-        }
+        pipeline = create_videosource(
+            source_pipeline, caps, "/com/stbtester/VideoSource", name);
     }
     catch (Error e) {
         GLib.stderr.printf ("Error: %s", e.message);
@@ -151,6 +90,7 @@ int main (string[] args) {
 
     // Creating and starting a GLib main loop
     new MainLoop().run();
+    pipeline.set_state(Gst.State.NULL);
     return 0;
 }
 


### PR DESCRIPTION
You no longer need to use the pulsevideo command line to create a
pulsevideo server on DBus.  Instead you can use `pulsevideosink` with
`gst-launch-1.0`.

```
gst-launch-1.0 videotestsrc ! pulsevideosink
```

is roughly equivilent to:

```
pulsevideo  --source-pipeline=videotestsrc
```
