### PR TITLE
Protocol: Add capture_timestamp to fdpay header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 dist: trusty
 
 install:
- - sudo add-apt-repository -y ppa:gstreamer-developers/ppa
  - sudo apt-get update
  - sudo apt-get install -y
         gir1.2-gstreamer-1.0

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ build/libgstpulsevideo.so : \
 		-DVERSION=\"$(VERSION)\" -DPACKAGE="\"pulsevideo\""
 
 build/gstvideosource1.c build/gstvideosource1.h : \
-		dbus-xml/com.stbtester.VideoSource1.xml
+		dbus-xml/com.stbtester.VideoSource2.xml
 	cd $(dir $@) && \
 	gdbus-codegen \
 		--generate-c-code $(basename $(notdir $@)) \

--- a/dbus-xml/com.stbtester.VideoSource2.xml
+++ b/dbus-xml/com.stbtester.VideoSource2.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
-  <interface name="com.stbtester.VideoSource1">
+  <interface name="com.stbtester.VideoSource2">
     <method name="Attach">
       <arg name="socket" type="h" direction="out"/>
       <annotation name="org.gtk.GDBus.C.UnixFD" value="True" />

--- a/gst/gstpulsevideosrc.c
+++ b/gst/gstpulsevideosrc.c
@@ -113,7 +113,7 @@ gst_pulsevideo_src_class_init (GstPulseVideoSrcClass * klass)
   gst_element_class_set_static_metadata (gstelement_class,
       "PulseVideo source", "Source/DBus",
       "Receive data from an object on DBus that exposes the "
-      "com.stbtester.VideoSource1 interface",
+      "com.stbtester.VideoSource2 interface",
       "William Manley <will@williammanley.net>");
 
   gstelement_class->change_state = gst_pulsevideo_src_change_state;
@@ -304,7 +304,7 @@ gst_pulsevideo_src_reinit (GstPulseVideoSrc * src, GError **error)
   gchar *object_path = NULL;
   GError *err = NULL;
 
-  GstVideoSource1 *videosource = NULL;
+  GstVideoSource2 *videosource = NULL;
   gboolean ret = PV_INIT_FAILURE;
   const gchar *scaps = NULL;
   GstCaps *caps = NULL;
@@ -328,7 +328,7 @@ gst_pulsevideo_src_reinit (GstPulseVideoSrc * src, GError **error)
     }
   }
 
-  videosource = gst_video_source1_proxy_new_sync (dbus,
+  videosource = gst_video_source2_proxy_new_sync (dbus,
       G_DBUS_PROXY_FLAGS_NONE, bus_name, object_path, src->cancellable, &err);
   if (!videosource) {
     GST_ELEMENT_ERROR (src, RESOURCE, NOT_FOUND, (NULL),
@@ -336,7 +336,7 @@ gst_pulsevideo_src_reinit (GstPulseVideoSrc * src, GError **error)
     goto done;
   }
 
-  scaps = gst_video_source1_get_caps (videosource);
+  scaps = gst_video_source2_get_caps (videosource);
   if (!scaps) {
     ret = PV_INIT_NOOBJECT;
     g_set_error(&err, g_quark_from_static_string ("pv-read-caps-error-quark"),
@@ -352,7 +352,7 @@ gst_pulsevideo_src_reinit (GstPulseVideoSrc * src, GError **error)
   gst_caps_unref (caps);
   caps = NULL;
 
-  if (!gst_video_source1_call_attach_sync (videosource, NULL, NULL, &fdlist,
+  if (!gst_video_source2_call_attach_sync (videosource, NULL, NULL, &fdlist,
           src->cancellable, &err)) {
     ret = PV_INIT_NOOBJECT;
     goto done;

--- a/gst/tmpfile/gstfddepay.h
+++ b/gst/tmpfile/gstfddepay.h
@@ -1,5 +1,5 @@
 /* GStreamer
- * Copyright (C) 2014 William Manley <will@williammanley.net>
+ * Copyright (C) 2014-2016 William Manley <will@williammanley.net>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -35,6 +35,7 @@ struct _GstFddepay
 {
   GstBaseTransform base_fddepay;
   GstAllocator *fd_allocator;
+  GstClock *monotonic_clock;
 };
 
 struct _GstFddepayClass

--- a/gst/tmpfile/gstfdpay.h
+++ b/gst/tmpfile/gstfdpay.h
@@ -1,5 +1,5 @@
 /* GStreamer
- * Copyright (C) 2014 William Manley <will@williammanley.net>
+ * Copyright (C) 2014-2016 William Manley <will@williammanley.net>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,6 +36,7 @@ struct _GstFdpay
   GstBaseTransform base_fdpay;
   GstAllocator * allocator;
 
+  GstClock *monotonic_clock;
 };
 
 struct _GstFdpayClass

--- a/gst/tmpfile/wire-protocol.h
+++ b/gst/tmpfile/wire-protocol.h
@@ -1,5 +1,5 @@
 /* GStreamer
- * Copyright (C) 2014 William Manley <will@williammanley.net>
+ * Copyright (C) 2014-2016 William Manley <will@williammanley.net>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -26,6 +26,9 @@
  * a file-descriptor attached which should be mmapable.  The data in the FD can
  * be found at offset and is size bytes long. */
 typedef struct {
+  /* Time at which the frame was originally captured against the CLOCK_MONOTONIC
+   * in ns */
+  uint64_t capture_timestamp;
   uint64_t offset;
   uint64_t size;
 } FDMessage;

--- a/pulsevideo.vala
+++ b/pulsevideo.vala
@@ -3,8 +3,8 @@ using Gst;
 using Posix;
 
 
-[DBus (name = "com.stbtester.VideoSource1")]
-public interface VideoSource1 : GLib.Object {
+[DBus (name = "com.stbtester.VideoSource2")]
+public interface VideoSource2 : GLib.Object {
 
     public abstract string caps { owned get; }
     public abstract GLib.UnixInputStream attach () throws Error;
@@ -16,7 +16,7 @@ GLib.Error ioerror_from_errno (int err_no, string msg)
         msg);
 }
 
-public class VideoSource : GLib.Object, VideoSource1 {
+public class VideoSource : GLib.Object, VideoSource2 {
 
     public string caps { owned get { return caps_; } }
     private string caps_;
@@ -85,7 +85,7 @@ void create_videosource(string source, string caps, GLib.DBusConnection dbus,
     var sink = pipeline.get_by_name("sink");
 
     dbus.register_object(object_path,
-        (VideoSource1) new VideoSource(caps, pipeline, sink));
+        (VideoSource2) new VideoSource(caps, pipeline, sink));
 }
 
 int main (string[] args) {


### PR DESCRIPTION
The capture_timestamp is the time at which the video-frame was captured
(e.g. from v4l) as measured against the Linux CLOCK_MONOTONIC clock.  This
is useful for synchronisation between multiple sources.  the monotonic
clock was chosen because that is the format most v4l and alsa devices
provide their data in.

This is a backward incompatible change to the wire-protocol so I have
bumped the DBus interface version number.  Old versions and new versions
of pulsevideo will not interoperate, but at least they will fail early and
loudly.