### PR TITLE
Fix clock slaving

### DIFF
--- a/gst/tmpfile/gstfddepay.c
+++ b/gst/tmpfile/gstfddepay.c
@@ -263,10 +263,24 @@ gst_fddepay_transform_ip (GstBaseTransform * trans, GstBuffer * buf)
     if (GST_ELEMENT (trans)->base_time < pipeline_clock_time) {
       running_time = pipeline_clock_time - GST_ELEMENT (trans)->base_time;
     } else {
+      GST_INFO_OBJECT (trans, "base time < clock time! %" GST_TIME_FORMAT " < "
+          "%" GST_TIME_FORMAT, GST_TIME_ARGS (GST_ELEMENT (trans)->base_time),
+          GST_TIME_ARGS (pipeline_clock_time));
       running_time = 0;
     }
     GST_BUFFER_PTS (buf) = gst_segment_to_position (
         &trans->segment, GST_FORMAT_TIME, running_time);
+
+    GST_DEBUG_OBJECT (trans, "CLOCK_MONOTONIC capture timestamp %"
+        GST_TIME_FORMAT " -> pipeline clock time %" GST_TIME_FORMAT " -> "
+        "running time %" GST_TIME_FORMAT " -> PTS %" GST_TIME_FORMAT,
+        GST_TIME_ARGS (msg.capture_timestamp),
+        GST_TIME_ARGS (pipeline_clock_time), GST_TIME_ARGS (running_time),
+        GST_TIME_ARGS (GST_BUFFER_PTS (buf)));
+
+  } else {
+    GST_INFO_OBJECT (trans, "Can't apply timestamp to buffer: segment.format "
+        "!= GST_FORMAT_TIME");
   }
   return GST_FLOW_OK;
 error:

--- a/gst/tmpfile/gstfddepay.c
+++ b/gst/tmpfile/gstfddepay.c
@@ -109,7 +109,7 @@ gst_fddepay_class_init (GstFddepayClass * klass)
       "William Manley <will@williammanley.net>");
 
   gobject_class->dispose = gst_fddepay_dispose;
-  gstelement_class->set_clock = gst_fddepay_set_clock;
+  gstelement_class->set_clock = GST_DEBUG_FUNCPTR (gst_fddepay_set_clock);
   base_transform_class->transform_caps =
       GST_DEBUG_FUNCPTR (gst_fddepay_transform_caps);
   base_transform_class->transform_ip =
@@ -180,7 +180,7 @@ gst_fddepay_set_clock (GstElement * element, GstClock * clock)
 {
   GstFddepay *fddepay = GST_FDDEPAY (element);
 
-  GST_DEBUG_OBJECT (fddepay, "set_clock");
+  GST_DEBUG_OBJECT (fddepay, "set_clock (%" GST_PTR_FORMAT ")", clock);
 
   if (!gst_clock_set_master (fddepay->monotonic_clock, clock)) {
     GST_WARNING_OBJECT (element, "Failed to slave internal MONOTONIC clock %"

--- a/gst/tmpfile/gstfddepay.c
+++ b/gst/tmpfile/gstfddepay.c
@@ -182,7 +182,16 @@ gst_fddepay_set_clock (GstElement * element, GstClock * clock)
 
   GST_DEBUG_OBJECT (fddepay, "set_clock (%" GST_PTR_FORMAT ")", clock);
 
-  if (!gst_clock_set_master (fddepay->monotonic_clock, clock)) {
+  if (gst_clock_set_master (fddepay->monotonic_clock, clock)) {
+    if (clock) {
+      /* gst_clock_set_master is asynchronous and may take some time to sync.
+       * To give it a helping hand we'll initialise it here so we don't send
+       * through spurious timings with the first buffer. */
+      gst_clock_set_calibration (fddepay->monotonic_clock,
+          gst_clock_get_internal_time (fddepay->monotonic_clock),
+          gst_clock_get_time (clock), 1, 1);
+    }
+  } else {
     GST_WARNING_OBJECT (element, "Failed to slave internal MONOTONIC clock %"
         GST_PTR_FORMAT " to master clock %" GST_PTR_FORMAT,
         fddepay->monotonic_clock, clock);

--- a/gst/tmpfile/gstfddepay.c
+++ b/gst/tmpfile/gstfddepay.c
@@ -179,9 +179,12 @@ gst_fddepay_set_clock (GstElement * element, GstClock * clock)
 {
   GstFddepay *fddepay = GST_FDDEPAY (element);
 
+  GST_DEBUG_OBJECT (fddepay, "set_clock");
+
   gst_clock_set_master (fddepay->monotonic_clock, clock);
 
-  return TRUE;
+  return GST_ELEMENT_CLASS (gst_fddepay_parent_class)->set_clock (element,
+      clock);
 }
 
 static GstFlowReturn

--- a/gst/tmpfile/gstfddepay.c
+++ b/gst/tmpfile/gstfddepay.c
@@ -125,6 +125,7 @@ gst_fddepay_init (GstFddepay * fddepay)
   fddepay->fd_allocator = gst_fd_allocator_new ();
   fddepay->monotonic_clock = g_object_new (GST_TYPE_SYSTEM_CLOCK,
       "clock-type", GST_CLOCK_TYPE_MONOTONIC, NULL);
+  GST_OBJECT_FLAG_SET (fddepay->monotonic_clock, GST_CLOCK_FLAG_CAN_SET_MASTER);
 }
 
 void

--- a/gst/tmpfile/gstfddepay.c
+++ b/gst/tmpfile/gstfddepay.c
@@ -120,6 +120,8 @@ gst_fddepay_class_init (GstFddepayClass * klass)
 static void
 gst_fddepay_init (GstFddepay * fddepay)
 {
+  GST_OBJECT_FLAG_SET (fddepay, GST_ELEMENT_FLAG_REQUIRE_CLOCK);
+
   fddepay->fd_allocator = gst_fd_allocator_new ();
   fddepay->monotonic_clock = g_object_new (GST_TYPE_SYSTEM_CLOCK,
       "clock-type", GST_CLOCK_TYPE_MONOTONIC, NULL);

--- a/gst/tmpfile/gstfddepay.c
+++ b/gst/tmpfile/gstfddepay.c
@@ -181,7 +181,11 @@ gst_fddepay_set_clock (GstElement * element, GstClock * clock)
 
   GST_DEBUG_OBJECT (fddepay, "set_clock");
 
-  gst_clock_set_master (fddepay->monotonic_clock, clock);
+  if (!gst_clock_set_master (fddepay->monotonic_clock, clock)) {
+    GST_WARNING_OBJECT (element, "Failed to slave internal MONOTONIC clock %"
+        GST_PTR_FORMAT " to master clock %" GST_PTR_FORMAT,
+        fddepay->monotonic_clock, clock);
+  }
 
   return GST_ELEMENT_CLASS (gst_fddepay_parent_class)->set_clock (element,
       clock);

--- a/gst/tmpfile/gstfdpay.c
+++ b/gst/tmpfile/gstfdpay.c
@@ -205,9 +205,12 @@ gst_fdpay_set_clock (GstElement * element, GstClock * clock)
 {
   GstFdpay *fdpay = GST_FDPAY (element);
 
+  GST_DEBUG_OBJECT (fdpay, "set_clock");
+
   gst_clock_set_master (fdpay->monotonic_clock, clock);
 
-  return TRUE;
+  return GST_ELEMENT_CLASS (gst_fdpay_parent_class)->set_clock (element,
+      clock);
 }
 
 static GstMemory *

--- a/gst/tmpfile/gstfdpay.c
+++ b/gst/tmpfile/gstfdpay.c
@@ -123,7 +123,7 @@ gst_fdpay_class_init (GstFdpayClass * klass)
       "William Manley <will@williammanley.net>");
 
   gobject_class->dispose = gst_fdpay_dispose;
-  gst_element_class->set_clock = gst_fdpay_set_clock;
+  gst_element_class->set_clock = GST_DEBUG_FUNCPTR (gst_fdpay_set_clock);
   base_transform_class->transform_caps =
       GST_DEBUG_FUNCPTR (gst_fdpay_transform_caps);
   base_transform_class->propose_allocation =
@@ -206,7 +206,7 @@ gst_fdpay_set_clock (GstElement * element, GstClock * clock)
 {
   GstFdpay *fdpay = GST_FDPAY (element);
 
-  GST_DEBUG_OBJECT (fdpay, "set_clock");
+  GST_DEBUG_OBJECT (fdpay, "set_clock (%" GST_PTR_FORMAT ")", clock);
 
   if (!gst_clock_set_master (fdpay->monotonic_clock, clock)) {
     GST_WARNING_OBJECT (element, "Failed to slave internal MONOTONIC clock %"
@@ -294,6 +294,9 @@ gst_fdpay_transform_ip (GstBaseTransform * trans, GstBuffer * buf)
 
   gst_buffer_append_memory (buf, msgmem);
   msgmem = NULL;
+
+  GST_DEBUG_OBJECT (trans, "transform_ip: Pushing {capture_timestamp: %lu, "
+      "offset: %lu, size: %lu}", msg.capture_timestamp, msg.offset, msg.size);
 
   return GST_FLOW_OK;
 append_fd_failed:

--- a/gst/tmpfile/gstfdpay.c
+++ b/gst/tmpfile/gstfdpay.c
@@ -207,7 +207,11 @@ gst_fdpay_set_clock (GstElement * element, GstClock * clock)
 
   GST_DEBUG_OBJECT (fdpay, "set_clock");
 
-  gst_clock_set_master (fdpay->monotonic_clock, clock);
+  if (!gst_clock_set_master (fdpay->monotonic_clock, clock)) {
+    GST_WARNING_OBJECT (element, "Failed to slave internal MONOTONIC clock %"
+        GST_PTR_FORMAT " to master clock %" GST_PTR_FORMAT,
+        fdpay->monotonic_clock, clock);
+  }
 
   return GST_ELEMENT_CLASS (gst_fdpay_parent_class)->set_clock (element,
       clock);

--- a/gst/tmpfile/gstfdpay.c
+++ b/gst/tmpfile/gstfdpay.c
@@ -135,6 +135,8 @@ gst_fdpay_class_init (GstFdpayClass * klass)
 static void
 gst_fdpay_init (GstFdpay * fdpay)
 {
+  GST_OBJECT_FLAG_SET (fdpay, GST_ELEMENT_FLAG_REQUIRE_CLOCK);
+
   fdpay->allocator = gst_tmpfile_allocator_new ();
   fdpay->monotonic_clock = g_object_new (GST_TYPE_SYSTEM_CLOCK,
       "clock-type", GST_CLOCK_TYPE_MONOTONIC, NULL);

--- a/gst/tmpfile/gstfdpay.c
+++ b/gst/tmpfile/gstfdpay.c
@@ -140,6 +140,7 @@ gst_fdpay_init (GstFdpay * fdpay)
   fdpay->allocator = gst_tmpfile_allocator_new ();
   fdpay->monotonic_clock = g_object_new (GST_TYPE_SYSTEM_CLOCK,
       "clock-type", GST_CLOCK_TYPE_MONOTONIC, NULL);
+  GST_OBJECT_FLAG_SET (fdpay->monotonic_clock, GST_CLOCK_FLAG_CAN_SET_MASTER);
 }
 
 void

--- a/tests/socketintegrationtest.c
+++ b/tests/socketintegrationtest.c
@@ -444,7 +444,7 @@ check_monotonic_timestamp_with_clock(GstClock * clock)
       "! appsink name=sink sync=false async=true", NULL));
 
   if (clock)
-    gst_pipeline_set_clock (pipeline, clock);
+    gst_pipeline_use_clock (pipeline, clock);
 
   clock_gettime (CLOCK_MONOTONIC, &ts);
   before = ts.tv_sec * 1000000000 + ts.tv_nsec;


### PR DESCRIPTION
Clock slaving was broken causing the timestamps in the buffers to be incorrect if the pipeline clock was not the monotonic clock.  As the monotonic clock is the default clock to use we didn't notice it while implementing #19.  I picked up on it while doing latency measurements with [latency-clock](https://github.com/stb-tester/latency-clock).

We had a test for this but it was broken.  ~~I'll have to fix it to confirm that this fix worked.~~ - Fixed in 21d3ac8.

Note: we use `GST_ELEMENT_FLAG_REQUIRE_CLOCK`, but it doesn't seem necessary from inspection of the GStreamer source code.

TODO:

- [x] Fix tests to show this issue