### PR TITLE
Ensure segments use GST_FORMAT_TIME with GStreamer 1.2 (Ubuntu 14.04)

### DIFF
--- a/gst/gstpulsevideosrc.c
+++ b/gst/gstpulsevideosrc.c
@@ -150,6 +150,7 @@ gst_pulsevideo_src_init (GstPulseVideoSrc * this)
   this->cancellable = g_cancellable_new ();
   this->socketsrc = gst_element_factory_make ("pvsocketsrc", NULL);
   gst_base_src_set_live (GST_BASE_SRC (this->socketsrc), TRUE);
+  gst_base_src_set_format (GST_BASE_SRC (this->socketsrc), GST_FORMAT_TIME);
   gst_bin_add (GST_BIN (this), gst_object_ref (this->socketsrc));
   this->fddepay = gst_element_factory_make ("pvfddepay", NULL);
   gst_bin_add (GST_BIN (this), gst_object_ref (this->fddepay));


### PR DESCRIPTION
With GStreamer 1.2 (Ubuntu 14.04) despite setting `do-timestamp=true` on the socketsrc, the socketsrc would still send segments with format GST_FORMAT_BYTES.  This would cause failures when attempting to use videorate downstream.  This was fixed in GStreamer 1.4.  See GStreamer bugzilla [#702842] for more information.

[#702842]: https://bugzilla.gnome.org/show_bug.cgi?id=702842