### PR TITLE
pulsevideosrc: Ensure that buffers in tmpfile memory are read-only

### DIFF
--- a/gst/tmpfile/gstfddepay.c
+++ b/gst/tmpfile/gstfddepay.c
@@ -267,6 +267,7 @@ gst_fddepay_transform_ip (GstBaseTransform * trans, GstBuffer * buf)
       msg.offset + msg.size, GST_FD_MEMORY_FLAG_NONE);
   fd = -1;
   gst_memory_resize (fdmem, msg.offset, msg.size);
+  GST_MINI_OBJECT_FLAG_SET (fdmem, GST_MEMORY_FLAG_READONLY);
 
   gst_buffer_remove_all_memory (buf);
   gst_buffer_remove_meta (buf,


### PR DESCRIPTION
This prevents clients from intefering with each other.  It's not secure
in that the FD sent across the socket is opened RW, so could be written
to but this should prevent accidental misuse.

You can still map the buffers with
`gst_buffer_map (..., GST_MAP_READWRITE)` because `GstBuffer` will
silently perform a copy on demand so clients shouldn't see any difference.