### PR TITLE
fdpay: Propose an bufferpool upstream if requested

### DIFF
--- a/gst/tmpfile/gstfdpay.c
+++ b/gst/tmpfile/gstfdpay.c
@@ -45,6 +45,7 @@
 #include <gst/gst.h>
 #include <gst/allocators/gstfdmemory.h>
 #include <gst/base/gstbasetransform.h>
+#include <gst/video/video.h>
 #include "gstfdpay.h"
 #include "gsttmpfileallocator.h"
 
@@ -194,9 +195,52 @@ gst_fdpay_propose_allocation (GstBaseTransform * trans,
 {
   GstFdpay *fdpay = GST_FDPAY (trans);
 
+  GstBufferPool *pool = NULL;
+  GstStructure *pool_config = NULL;
+  GstCaps *caps = NULL;
+  gboolean need_pool = FALSE;
+  GstVideoInfo info;
+
   GST_DEBUG_OBJECT (fdpay, "propose_allocation");
 
+  gst_query_parse_allocation (query, &caps, &need_pool);
+
+  /* Plain Allocator */
   gst_query_add_allocation_param (query, fdpay->allocator, NULL);
+
+  if (!need_pool) {
+    GST_INFO_OBJECT (fdpay, "No pool requested.  Not proposing pool");
+    goto no_pool;
+  }
+
+  if (caps == NULL) {
+    GST_WARNING_OBJECT (fdpay, "Pool requested but have no configured caps to "
+        "determine size.  Not proposing pool");
+    goto no_pool;
+  }
+
+  if (!gst_video_info_from_caps (&info, caps)) {
+    GST_WARNING_OBJECT (fdpay, "Don't know the appropriate size for caps %"
+        GST_PTR_FORMAT ".  Not proposing pool", caps);
+    goto no_pool;
+  }
+
+  pool_config = gst_structure_new_empty ("pool_config");
+  gst_buffer_pool_config_set_params (pool_config, caps, info.size, 0, 0);
+  gst_buffer_pool_config_set_allocator (pool_config, fdpay->allocator, NULL);
+
+  pool = gst_buffer_pool_new ();
+  if (!gst_buffer_pool_set_config (pool, pool_config)) {
+    GST_WARNING_OBJECT (fdpay, "Failed to set buffer pool config during "
+        "allocation query: Not proposing pool");
+    goto no_pool;
+  }
+
+  GST_INFO_OBJECT (fdpay, "Proposing pool");
+  gst_query_add_allocation_pool (query, pool, 0, 0, 0);
+
+no_pool:
+  g_clear_object (&pool);
 
   return TRUE;
 }


### PR DESCRIPTION
This will enable fdpay to work in pipelines with `v4l2src io-mode=userptr`.  In this mode v4l will write directly into our buffers reducing the copying by one.