### PR TITLE
Fix allocation with upstream v4l2src elements with io-mode=mmap

### DIFF
--- a/gst/tmpfile/gstfdpay.c
+++ b/gst/tmpfile/gstfdpay.c
@@ -203,6 +203,10 @@ gst_fdpay_propose_allocation (GstBaseTransform * trans,
 
   GST_DEBUG_OBJECT (fdpay, "propose_allocation");
 
+  if (!GST_BASE_TRANSFORM_CLASS (gst_fdpay_parent_class)->propose_allocation (trans,
+          decide_query, query))
+    return FALSE;
+
   gst_query_parse_allocation (query, &caps, &need_pool);
 
   /* Plain Allocator */


### PR DESCRIPTION
I'm not sure why this wasn't working, and I'm not sure why this fixes it, but it seems to follow the pattern I've seen in gst-plugins-base.