### PR TITLE
Report real caps rather than caps filter to clients

### DIFF
--- a/dbus-xml/com.stbtester.VideoSource2.xml
+++ b/dbus-xml/com.stbtester.VideoSource2.xml
@@ -5,6 +5,7 @@
     <method name="Attach">
       <arg name="socket" type="h" direction="out"/>
       <annotation name="org.gtk.GDBus.C.UnixFD" value="True" />
+      <arg name="caps" type="s" direction="out"/>
     </method>
     <property name="Caps" type="s" access="read"/>
   </interface>


### PR DESCRIPTION
This will allow passing through information like h264 codec_data
over pulsevideo.  This information is required to understand the
h264 packets, but can't be predicted in advance.

We now only register the dbus name after we're ready to send data.  This
ensures we have caps as soon as an attach call comes in.  It's also the
right thing to do, we don't want to offer our service if we can't provide
one.