### PR TITLE
mmap optimisations

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -10,6 +10,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: apt update
+      run: sudo apt-get update
     - name: apt install
       run: sudo apt-get install -y
         gir1.2-gstreamer-1.0

--- a/gst/tmpfile/gstfddepay.c
+++ b/gst/tmpfile/gstfddepay.c
@@ -264,7 +264,7 @@ gst_fddepay_transform_ip (GstBaseTransform * trans, GstBuffer * buf)
     goto error;
   }
   fdmem = gst_fd_allocator_alloc (fddepay->fd_allocator, fd,
-      msg.offset + msg.size, GST_FD_MEMORY_FLAG_NONE);
+      msg.offset + msg.size, GST_FD_MEMORY_FLAG_KEEP_MAPPED);
   fd = -1;
   gst_memory_resize (fdmem, msg.offset, msg.size);
   GST_MINI_OBJECT_FLAG_SET (fdmem, GST_MEMORY_FLAG_READONLY);

--- a/gst/tmpfile/gstfdpay.c
+++ b/gst/tmpfile/gstfdpay.c
@@ -276,38 +276,6 @@ gst_fdpay_set_clock (GstElement * element, GstClock * clock)
       clock);
 }
 
-#ifdef __arm__
-/*
- * Faster memcpy on with ARM NEON chips.  See
- * http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka13544.html
- * for more information.
- */
-static inline void
-fast_memcpy(void * restrict dest, const void * restrict src, int n)
-{
-  int remainder = n % 64;
-  n -= remainder;
-  asm volatile (
-      "NEONCopyPLD:                \n"
-      "    PLD [%[src], #0xC0]     \n"
-      "    VLDM %[src]!,{d0-d7}    \n"
-      "    VSTM %[dest]!,{d0-d7}   \n"
-      "    SUBS %[n],%[n],#0x40    \n"
-      "    BGT NEONCopyPLD         \n"
-      : [dest]"+r"(dest), [src]"+r"(src), [n]"+r"(n)
-      :
-      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "cc", "memory");
-  memcpy ((guint8*)dest, (const guint8*)src, remainder);
-}
-#else
-static inline void
-fast_memcpy(void * restrict dest, const void * restrict src, int n)
-{
-  memcpy(dest, src, n);
-}
-#endif
-
-
 static GstMemory *
 gst_fdpay_get_fd_memory (GstFdpay * tmpfilepay, GstBuffer * buffer)
 {
@@ -317,36 +285,21 @@ gst_fdpay_get_fd_memory (GstFdpay * tmpfilepay, GstBuffer * buffer)
       && gst_is_fd_memory (gst_buffer_peek_memory (buffer, 0)))
     out = gst_buffer_get_memory (buffer, 0);
   else {
-    GstMapInfo src_info, dest_info;
-    GstMemory *mem = NULL;
-    GstAllocationParams params = {0, 0, 0, 0};
+    GstMapInfo src_info;
     GST_INFO_OBJECT (tmpfilepay, "Buffer cannot be payloaded without copying");
     if (!gst_buffer_map (buffer, &src_info, GST_MAP_READ)) {
       GST_ERROR_OBJECT (tmpfilepay, "Failed to map input buffer");
-      goto out2;
+      goto out;
     }
-    mem = gst_allocator_alloc (tmpfilepay->allocator, src_info.size, &params);
-    if (mem == NULL) {
+
+    out = gst_tmpfile_allocator_copy_alloc(tmpfilepay->allocator,
+        src_info.data, src_info.size);
+    if (out == NULL)
       GST_ERROR_OBJECT (tmpfilepay, "Failed to create new GstMemory");
-      goto out;
-    }
-    if (!gst_memory_map (mem, &dest_info, GST_MAP_WRITE)) {
-      GST_ERROR_OBJECT (tmpfilepay, "Failed to map output buffer");
-      goto out;
-    }
 
-    fast_memcpy(dest_info.data, src_info.data, src_info.size);
-
-    gst_memory_unmap (mem, &dest_info);
-
-    out = mem;
-    mem = NULL;
-out:
     gst_buffer_unmap (buffer, &src_info);
-out2:
-    if (mem)
-      gst_memory_unref (mem);
   }
+out:
   return out;
 }
 

--- a/gst/tmpfile/gsttmpfileallocator.c
+++ b/gst/tmpfile/gsttmpfileallocator.c
@@ -138,7 +138,7 @@ gst_tmpfile_allocator_alloc (GstAllocator * allocator, gsize size,
   if (fd < 0)
     return NULL;
   mem = gst_fd_allocator_alloc (alloc->fd_allocator, fd, maxsize,
-      GST_FD_MEMORY_FLAG_NONE);
+      GST_FD_MEMORY_FLAG_KEEP_MAPPED);
   gst_memory_resize (mem, pad (params->prefix, params->align), size);
   return mem;
 }

--- a/gst/tmpfile/gsttmpfileallocator.h
+++ b/gst/tmpfile/gsttmpfileallocator.h
@@ -27,5 +27,8 @@ G_BEGIN_DECLS
 /* Allocator that allocates memory from a file stored on a tmpfs */
 GstAllocator* gst_tmpfile_allocator_new (void);
 
+GstMemory * gst_tmpfile_allocator_copy_alloc (GstAllocator * alloc,
+    const void * data, size_t n);
+
 G_END_DECLS
 #endif


### PR DESCRIPTION
This is faster because:

* There are fewer `mmap`/`munmap` calls, and the resulting TLB churn
* The kernel can make optimisations as it doesn't need to zero the pages before writing into them.

**TODO**:

- [x] Debug test failure caused by `GST_FD_MEMORY_FLAG_KEEP_MAPPED`
    - cmd: `GST_DEBUG=GST_MEMORY:7 G_DEBUG=fatal-warnings gdb --args ./pulsevideo --caps=video/x-raw,format=RGB,width=320,height=240,framerate=10/1 --source-pipeline='videotestsrc pattern=white ! rndbuffersize min=230399 max=230401'`