### PR TITLE
DBus: Return error from Attach if caps not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,13 +87,13 @@ check-gst: ./tests/socketintegrationtest
 	GST_PLUGIN_PATH=$(CURDIR)/build LD_LIBRARY_PATH=$(CURDIR)/build ./tests/socketintegrationtest
 
 check-gst-gdb: ./tests/socketintegrationtest
-	GST_PLUGIN_PATH=$(CURDIR)/build LD_LIBRARY_PATH=$(CURDIR)/build CK_FORK=no G_DEBUG=fatal_warnings gdb ./tests/socketintegrationtest
+	GST_PLUGIN_PATH=$(CURDIR)/build LD_LIBRARY_PATH=$(CURDIR)/build CK_FORK=no G_DEBUG=fatal-warnings gdb ./tests/socketintegrationtest
 
 check-gst-valgrind: ./tests/socketintegrationtest common/
 	GST_PLUGIN_PATH=$(CURDIR)/build \
 	G_SLICE=always-malloc \
 	LD_LIBRARY_PATH=$(CURDIR)/build \
-	G_DEBUG=fatal_warnings \
+	G_DEBUG=fatal-warnings \
 	valgrind --tool=memcheck \
 	         --suppressions=./common/gst.supp \
 	         --leak-check=full \

--- a/gst/gstpulsevideosink.c
+++ b/gst/gstpulsevideosink.c
@@ -362,11 +362,13 @@ on_handle_attach (GstVideoSource2         *interface,
   inpad = gst_element_get_static_pad (sink->fdpay, "sink");
   g_assert (inpad);
   caps = gst_pad_get_current_caps (inpad);
-  /* We will always have caps at this point because we don't register the dbus
+  /* We should have caps at this point because we don't register the dbus
    * callback until the child elements are at least in state PAUSED, so should
    * have completed caps negotiation */
-  if (!caps)
+  if (!caps) {
+    g_set_error (&gerror, G_IO_ERROR, G_IO_ERROR_FAILED, "Caps not available");
     goto out;
+  }
   caps_str = gst_caps_to_string (caps);
 
   static struct FaultInjectionPoint pre_attach = FAULT_INJECTION_POINT("pre_attach");

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -33,7 +33,7 @@ def pulsevideo_cmdline(source_pipeline=None):
     return ['/usr/bin/env',
             'GST_PLUGIN_PATH=%s/../build' % os.path.dirname(__file__),
             'LD_LIBRARY_PATH=%s/../build/' % os.path.dirname(__file__),
-            'G_DEBUG=fatal_warnings',
+            'G_DEBUG=fatal-warnings',
             '%s/../pulsevideo' % os.path.dirname(__file__),
             '--caps=video/x-raw,format=RGB,width=320,height=240,framerate=10/1',
             '--source-pipeline=%s' % source_pipeline,


### PR DESCRIPTION
Without this if we don't have caps at `Attach` time the pulsevideo server
won't send any response to the `Attach` call, leading to the client hanging
for 25s until the DBus timeout is reached.  This was causing errors.
Instead now an error will be returned and the client will attempt to
reconnect.  When the reconnection is complete maybe it'll be fixed.

This is obviously still suboptimal, but it's a lot better than it was.

