### PR TITLE
wire-protocol: Send buffer data in-line below a certain size

### DIFF
--- a/gst/gstpulsevideosink.c
+++ b/gst/gstpulsevideosink.c
@@ -359,7 +359,7 @@ on_handle_attach (GstVideoSource2         *interface,
 
   g_signal_emit_by_name (sink->socketsink, "add", our_socket, NULL);
 
-  inpad = gst_element_get_static_pad (sink->fdpay, "sink");
+  inpad = gst_element_get_static_pad (sink->socketsink, "sink");
   g_assert (inpad);
   caps = gst_pad_get_current_caps (inpad);
   /* We should have caps at this point because we don't register the dbus

--- a/gst/gstpulsevideosrc.c
+++ b/gst/gstpulsevideosrc.c
@@ -159,12 +159,10 @@ gst_pulsevideo_src_init (GstPulseVideoSrc * this)
   gst_bin_add (GST_BIN (this), gst_object_ref (this->socketsrc));
   this->fddepay = gst_element_factory_make ("pvfddepay", NULL);
   gst_bin_add (GST_BIN (this), gst_object_ref (this->fddepay));
-  this->capsfilter = gst_element_factory_make ("capsfilter", NULL);
-  gst_bin_add (GST_BIN (this), gst_object_ref (this->capsfilter));
   rawvideovalidate = gst_element_factory_make ("rawvideovalidate", NULL);
   gst_bin_add (GST_BIN (this), rawvideovalidate);
   gst_element_link_many (
-        this->socketsrc, this->fddepay, this->capsfilter, rawvideovalidate,
+        this->socketsrc, this->fddepay, rawvideovalidate,
         NULL);
 
   internal_pad = gst_element_get_static_pad (rawvideovalidate, "src");
@@ -190,7 +188,6 @@ gst_pulsevideo_src_finalize (GObject * gobject)
   g_clear_object (&this->dbus);
   g_clear_object (&this->socketsrc);
   g_clear_object (&this->fddepay);
-  g_clear_object (&this->capsfilter);
 
   G_OBJECT_CLASS (parent_class)->finalize (gobject);
 }
@@ -391,9 +388,9 @@ gst_pulsevideo_src_reinit (GstPulseVideoSrc * src, GCancellable* cancellable,
 
   g_assert (scaps);
   caps = gst_caps_from_string (g_steal_pointer (&scaps));
-  g_object_set (src->capsfilter, "caps", caps, NULL);
 
   GST_INFO_OBJECT (src, "Received remote caps %" GST_PTR_FORMAT, caps);
+  g_object_set (src->socketsrc, "caps", caps, NULL);
   gst_caps_unref (g_steal_pointer (&caps));
 
   fds = g_unix_fd_list_steal_fds (fdlist, NULL);

--- a/gst/gstpulsevideosrc.h
+++ b/gst/gstpulsevideosrc.h
@@ -48,7 +48,6 @@ struct _GstPulseVideoSrc {
   /*< private >*/
   GstElement *socketsrc;
   GstElement *fddepay;
-  GstElement *capsfilter;
   GDBusConnection *dbus;
   gchar *bus_name;
   gchar *object_path;

--- a/gst/gstsocketsrc.c
+++ b/gst/gstsocketsrc.c
@@ -65,6 +65,7 @@ enum
 {
   PROP_0,
   PROP_SOCKET,
+  PROP_CAPS,
 };
 
 enum
@@ -81,6 +82,7 @@ G_DEFINE_TYPE (GstSocketSrc, gst_socket_src, GST_TYPE_PUSH_SRC);
 
 static void gst_socket_src_finalize (GObject * gobject);
 
+static GstCaps *gst_socketsrc_getcaps (GstBaseSrc * src, GstCaps * filter);
 static GstFlowReturn gst_socket_src_fill (GstPushSrc * psrc,
     GstBuffer * outbuf);
 static gboolean gst_socket_src_unlock (GstBaseSrc * bsrc);
@@ -115,6 +117,11 @@ gst_socket_src_class_init (GstSocketSrcClass * klass)
           "The socket to receive packets from", G_TYPE_SOCKET,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
+  g_object_class_install_property (gobject_class, PROP_CAPS,
+      g_param_spec_boxed ("caps", "Caps",
+          "The caps of the source pad", GST_TYPE_CAPS,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   gst_socket_src_signals[ON_SOCKET_EOS] =
     g_signal_new ("on-socket-eos", G_TYPE_FROM_CLASS (klass),
         G_SIGNAL_RUN_FIRST, G_STRUCT_OFFSET (GstSocketSrcClass, on_socket_eos),
@@ -129,6 +136,7 @@ gst_socket_src_class_init (GstSocketSrcClass * klass)
       "Thomas Vander Stichele <thomas at apestaart dot org>, "
       "William Manley <will@williammanley.net>");
 
+  gstbasesrc_class->get_caps = gst_socketsrc_getcaps;
   gstbasesrc_class->unlock = gst_socket_src_unlock;
   gstbasesrc_class->unlock_stop = gst_socket_src_unlock_stop;
 
@@ -149,6 +157,8 @@ gst_socket_src_finalize (GObject * gobject)
 {
   GstSocketSrc *this = GST_SOCKET_SRC (gobject);
 
+  if (this->caps)
+    gst_caps_unref (this->caps);
   if (this->cancellable)
     g_object_unref (this->cancellable);
   this->cancellable = NULL;
@@ -157,6 +167,32 @@ gst_socket_src_finalize (GObject * gobject)
   this->socket = NULL;
 
   G_OBJECT_CLASS (parent_class)->finalize (gobject);
+}
+
+static GstCaps *
+gst_socketsrc_getcaps (GstBaseSrc * src, GstCaps * filter)
+{
+  GstSocketSrc *socketsrc;
+  GstCaps *caps, *result;
+
+  socketsrc = GST_SOCKET_SRC (src);
+
+  GST_OBJECT_LOCK (src);
+  if ((caps = socketsrc->caps))
+    gst_caps_ref (caps);
+  GST_OBJECT_UNLOCK (src);
+
+  if (caps) {
+    if (filter) {
+      result = gst_caps_intersect_full (filter, caps, GST_CAPS_INTERSECT_FIRST);
+      gst_caps_unref (caps);
+    } else {
+      result = caps;
+    }
+  } else {
+    result = (filter) ? gst_caps_ref (filter) : gst_caps_new_any ();
+  }
+  return result;
 }
 
 static GstFlowReturn
@@ -287,6 +323,29 @@ gst_socket_src_set_property (GObject * object, guint prop_id,
       g_clear_object (&socket);
       break;
     }
+    case PROP_CAPS:
+    {
+      const GstCaps *new_caps_val = gst_value_get_caps (value);
+      GstCaps *new_caps;
+      GstCaps *old_caps;
+
+      if (new_caps_val == NULL) {
+        new_caps = gst_caps_new_any ();
+      } else {
+        new_caps = gst_caps_copy (new_caps_val);
+      }
+
+      GST_OBJECT_LOCK (socketsrc);
+      old_caps = socketsrc->caps;
+      socketsrc->caps = new_caps;
+      GST_OBJECT_UNLOCK (socketsrc);
+
+      if (old_caps)
+        gst_caps_unref (old_caps);
+
+      gst_pad_mark_reconfigure (GST_BASE_SRC_PAD (socketsrc));
+      break;
+    }
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -302,6 +361,11 @@ gst_socket_src_get_property (GObject * object, guint prop_id,
   switch (prop_id) {
     case PROP_SOCKET:
       g_value_set_object (value, socketsrc->socket);
+      break;
+    case PROP_CAPS:
+      GST_OBJECT_LOCK (socketsrc);
+      gst_value_set_caps (value, socketsrc->caps);
+      GST_OBJECT_UNLOCK (socketsrc);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);

--- a/gst/gstsocketsrc.h
+++ b/gst/gstsocketsrc.h
@@ -48,6 +48,7 @@ struct _GstSocketSrc {
   GstPushSrc element;
 
  /*< private >*/
+  GstCaps *caps;
   GSocket *socket;
   GCancellable *cancellable;
 };

--- a/gst/tmpfile/gstfddepay.h
+++ b/gst/tmpfile/gstfddepay.h
@@ -20,7 +20,7 @@
 #ifndef _GST_FDDEPAY_H_
 #define _GST_FDDEPAY_H_
 
-#include <gst/base/gstbasetransform.h>
+#include <gst/base/gstbaseparse.h>
 
 G_BEGIN_DECLS
 #define GST_TYPE_FDDEPAY   (gst_fddepay_get_type())
@@ -33,14 +33,14 @@ typedef struct _GstFddepayClass GstFddepayClass;
 
 struct _GstFddepay
 {
-  GstBaseTransform base_fddepay;
+  GstBaseParse base_fddepay;
   GstAllocator *fd_allocator;
   GstClock *monotonic_clock;
 };
 
 struct _GstFddepayClass
 {
-  GstBaseTransformClass base_fddepay_class;
+  GstBaseParseClass base_fddepay_class;
 };
 
 GType gst_fddepay_get_type (void);

--- a/gst/tmpfile/wire-protocol.h
+++ b/gst/tmpfile/wire-protocol.h
@@ -29,7 +29,7 @@ typedef struct {
   /* Time at which the frame was originally captured against the CLOCK_MONOTONIC
    * in ns */
   uint64_t capture_timestamp;
-  uint64_t offset;
+  int64_t offset;
   uint64_t size;
 } FDMessage;
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -300,6 +300,19 @@ def test_that_we_can_tee_fddepay():
     assert wait_until(lambda: fc2.count > 1)
 
 
+def test_pay_depay():
+    os.environ['GST_DEBUG'] = "4,*videosource*:9"
+    CAPS = 'video/x-raw,format=RGB,width=320,height=240,framerate=10/1'
+    gst_launch = subprocess.Popen(
+        ['gst-launch-1.0', 'videotestsrc', 'is-live=true', '!', CAPS,
+         '!', 'pvfdpay', '!', 'pvfddepay', '!', 'fdsink', 'fd=1'],
+         stdout=subprocess.PIPE)
+    fc1 = FrameCounter(gst_launch.stdout)
+    fc1.start()
+
+    assert wait_until(lambda: fc1.count > 1)
+
+
 def test_that_backing_memory_is_not_reused(pulsevideo):
     """
     This is a regression test.  There used to be a problem where only one


### PR DESCRIPTION
Below a certain size it's faster to copy the data than it is to use `mmap`.
This will make pulsevideo more efficient for audio and encoded video data.