### PR TITLE
Don't use mmap below a certain size threshold

### DIFF
--- a/gst/tmpfile/gsttmpfileallocator.h
+++ b/gst/tmpfile/gsttmpfileallocator.h
@@ -30,5 +30,7 @@ GstAllocator* gst_tmpfile_allocator_new (void);
 GstMemory * gst_tmpfile_allocator_copy_alloc (GstAllocator * alloc,
     const void * data, size_t n);
 
+gsize tmpfile_mmap_threshold (void);
+
 G_END_DECLS
 #endif


### PR DESCRIPTION
`mmap` is slower than copying for small buffers.  With this commit, if the
size of the buffer is below some threshold we'll use `write` and `read`
to payload/depayload.  We still use an FD transport in this case though.

I've set the threshold to 100KB, but it is customiseable via the
`TMPFILE_MMAP_THRESHOLD` environment variable so we can experiment with
different values easily.

This is an alternative to #35.