### PR TITLE
pulsevideosink: Block `Attach` method until caps arrive

### DIFF
--- a/gst/gstpulsevideosrc.c
+++ b/gst/gstpulsevideosrc.c
@@ -311,6 +311,10 @@ is_dbus_error_recoverable(GError * err)
   /* These errors are associated with the remote pulsevideo crashing, in which
    * case we can try and reconnect.  We don't want to reconnect unconditionally
    * as this can just make things worse (e.g. resource starvation) */
+  if (g_error_matches (err, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN))
+    return FALSE;
+  if (g_dbus_error_is_remote_error (err))
+    return TRUE;
   return g_error_matches (err, G_DBUS_ERROR, G_DBUS_ERROR_NO_REPLY) ||
     g_error_matches (err, G_DBUS_ERROR, G_DBUS_ERROR_SPAWN_CHILD_EXITED) ||
     g_error_matches (err, G_DBUS_ERROR, G_DBUS_ERROR_SPAWN_CHILD_SIGNALED) ||


### PR DESCRIPTION
It turns out that our assumption that caps will be set by the time `Attach`
is called is false.  Now we no longer rely on that, instead we wait until
caps actually arrive.

I'm not 100% sure what thread this will be run from, (i.e. which thread
we'll be blocking with our sleeps) but I think it will be the GLib Mainloop
which should be ok as we'll only be sleeping a short amount of time in
practice.  I don't want to complicate this function any further with async,
etc.