### PR TITLE
Ubuntu 20.04 build fixes

### DIFF
--- a/gst/gstpulsevideosink.c
+++ b/gst/gstpulsevideosink.c
@@ -312,6 +312,7 @@ failure:
   }
 }
 
+#if GST_VERSION_MINOR < 16
 static void
 gst_clear_caps (GstCaps **pcaps)
 {
@@ -320,6 +321,7 @@ gst_clear_caps (GstCaps **pcaps)
     *pcaps = NULL;
   }
 }
+#endif
 
 static gboolean
 on_handle_attach (GstVideoSource2         *interface,


### PR DESCRIPTION
- [x] error: redefinition of ‘gst_clear_caps’
- [ ] deprecation warnings in `tcp/gstmultihandlesink.c` and `tcp/gstmultisocketsink.c`:
  - warning: ‘GTimeVal’ is deprecated: Use 'GDateTime' instead
  - warning: ‘g_get_current_time’ is deprecated: Use 'g_get_real_time' instead

[gst_clear_caps] added in GStreamer 1.16.
[GDateTime] added in GLib 2.26.
[g_get_real_time] added in GLib 2.28.

Ubuntu 16.04 has GLib 2.48 and GStreamer 1.8.
Ubuntu 18.04 has GLib 2.56 and GStreamer 1.14.
Ubuntu 20.04 has GStreamer 1.16.

[GDateTime]: https://developer-old.gnome.org/glib/stable/glib-GDateTime.html
[g_get_real_time]: https://developer-old.gnome.org/glib/stable/glib-Date-and-Time-Functions.html#g-get-real-time
